### PR TITLE
Change JDK7 url to use Oracle's archive page

### DIFF
--- a/list-jdk/src/main/java/ListJDK.java
+++ b/list-jdk/src/main/java/ListJDK.java
@@ -41,7 +41,7 @@ public class ListJDK {
         return new JSONObject()
             .element("version", 2)
             .element("data",new JSONArray()
-                .element(family("JDK 7", parse("http://www.oracle.com/technetwork/java/javase/downloads/java-se-jdk-7-download-432154.html")))
+                .element(family("JDK 7", parse("http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html")))
                 .element(family("JDK 6", parse("http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html")))
                 .element(family("JDK 5", parse("http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase5-419410.html")))
                 .element(family("JDK 1.4", parse("http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase14-419411.html"))));


### PR DESCRIPTION
Currently, only JDK7 is listed in the jenkins update center. I've switched the url used for getting the list of releases to the archive site to make it consistent with the other releases (JDK5, JDK6).

One important thing to note is that the archive sites still do not include the latest update of each release (ie, last release of JDK6 is u31, but only u0-u30 is listed on the archive site). We'll need to figure out how to scrape for the latest updates and append them to the top of the list somehow.
