### PR TITLE
Update URL for Gradle Distributions

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -9,7 +9,7 @@ import net.sf.json.*
 import com.gargoylesoftware.htmlunit.WebClient
 
 def wc = new WebClient()
-def baseUrl = 'http://repo.gradle.org/gradle/distributions/'
+def baseUrl = 'http://services.gradle.org/distributions'
 HtmlPage p = wc.getPage(baseUrl);
 
 def json = [];


### PR DESCRIPTION
The Gradle guys are using a new URL for their distributions. This is needed to be able to auto-install Gradle Milestone 9 into Jenkins. The older versions are also published to the new URL, so it shouldn't break any existing installations.
