### PR TITLE
Fix for Gradle distribution URL

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -9,8 +9,8 @@ import net.sf.json.*
 import com.gargoylesoftware.htmlunit.WebClient
 
 def wc = new WebClient()
-def baseUrl = 'http://services.gradle.org/distributions'
-HtmlPage p = wc.getPage(baseUrl);
+def baseUrl = 'http://services.gradle.org'
+HtmlPage p = wc.getPage(baseUrl + '/distributions');
 
 def json = [];
 


### PR DESCRIPTION
Previous pull request will generate incorrect URLs with part of the URL path being duplicated. This pull request fixes the problem. I've tested the URL generated for the Milestone 9 distribution and it resolved correctly.
