### PR TITLE
Support for nodejs crawler

### DIFF
--- a/nodejs.groovy
+++ b/nodejs.groovy
@@ -9,31 +9,7 @@ def wc = new WebClient()
 def baseUrl = 'http://nodejs.org/dist'
 HtmlPage p = wc.getPage(baseUrl);
 
-class Version implements Comparable<Version> {
-  private String url
-  private Integer major;
-  private Integer minor;
-  private Integer patch;
-  Version(String url, Integer major, Integer minor, Integer patch){
-    this.url = url; this.major = major; this.minor = minor; this.patch = patch;
-  }
-  public int compareTo(Version v){
-    int cmp = major.compareTo(v.major);
-    if(cmp == 0){
-      cmp = minor.compareTo(v.minor);
-      if(cmp == 0){
-        return patch.compareTo(v.patch);
-      }
-    }
-    return cmp;
-  }
-  public String toString(){
-    return this.major+"."+this.minor+"."+this.patch;
-  }
-}
-
 def json = [];
-def versions = new TreeSet();
 
 p.selectNodes("//a[@href]").reverse().collect { HtmlAnchor e ->
     def url = baseUrl + "/" + e.getHrefAttribute()
@@ -41,13 +17,8 @@ p.selectNodes("//a[@href]").reverse().collect { HtmlAnchor e ->
     String versionRegex = "v(\\d+(?:\\.\\d+)*)/";
     def m = (url =~ versionRegex)
     if (m) {
-        def chunkedVersions = m[0][1].split("\\.");
-        versions << new Version(url, chunkedVersions[0].toInteger(), chunkedVersions[1].toInteger(), chunkedVersions[2].toInteger());
+        json << ["id": m[0][1], "name": "NodeJS ${m[0][1]}".toString(), "url": url];
     }
-}
-
-(versions as List).reverse().collect { Version v ->
-  json << ["id": v.toString(), "name": "NodeJS ${v}".toString(), "url": v.url];
 }
 
 lib.DataWriter.write("hudson.plugins.nodejs.tools.NodeJSInstaller",JSONObject.fromObject([list:json]));


### PR DESCRIPTION
Added a new NodeJS Crawler allowing to fetch available NodeJS versions from http://nodejs.org/dist
Will be needed for upcoming NodeJS+npm jenkins autoinstallers
