### PR TITLE
Add Java 8 installer

### DIFF
--- a/jdk.groovy
+++ b/jdk.groovy
@@ -27,6 +27,7 @@ public class ListJDK {
         return new JSONObject()
                 .element("version", 2)
                 .element("data", new JSONArray()
+                        .element(family("JDK 8", parse("http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html")))
                         .element(family("JDK 7", combine(
                             parse("http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html"),
                             parse("http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"))))


### PR DESCRIPTION
I had some issues running locally (lots of problems grabbing jars via Groovy's Grapes, had to exclude a few things), then had problems downloading the binary from oracle, said I needed to accept license, however, it works fine for others. I just wanted to get others to help debug this.
