### PR TITLE
[JENKINS-22237] Gradle available versions should be in descending order.

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -11,7 +11,7 @@ HtmlPage p = wc.getPage(baseUrl + '/distributions');
 
 def json = [];
 
-p.selectNodes("//a[@href]").reverse().collect { HtmlAnchor e ->
+p.selectNodes("//a[@href]").collect { HtmlAnchor e ->
     def url = baseUrl + e.getHrefAttribute()
     println url
     def m = (url =~ /gradle-(.*)-bin.zip$/)


### PR DESCRIPTION
The list of gradle distributions provided on "http://services.gradle.org/distributions" is already given in descending order and no ordering is necessary.
