### PR TITLE
sbt: download 1.x artifacts from github, but source versions from maven

### DIFF
--- a/sbt.groovy
+++ b/sbt.groovy
@@ -32,14 +32,13 @@ def listFromMaven() {
     return versions.collect() { version ->
         return ["id"  : version,
                 "name": version,
-                "url" : getMavenArtifactUrl(baseUrl, version)
+                "url" : getGithubArtifactUrl(version)
         ]
     }
 }
 
-def getMavenArtifactUrl(String baseUrl, String version) {
-    def artifactName = String.format("sbt-%s.jar", version)
-    return String.format('%s/%s/%s', baseUrl, version, artifactName);
+def getGithubArtifactUrl(String version) {
+    return String.format("https://github.com/sbt/sbt/releases/download/v%s/sbt-%s.zip", version, version)
 }
 
 def listAll() {


### PR DESCRIPTION
Extending fro https://github.com/jenkins-infra/crawler/pull/67 the `.jar` downloads fail, but sbt offers `.zip` files that probably work the same as `0.13.x` installs. 