### PR TITLE
Ignore JavaScript error in Gradle crawler.

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -6,6 +6,8 @@ import com.gargoylesoftware.htmlunit.WebClient
 import net.sf.json.*
 
 def wc = new WebClient()
+wc.setThrowExceptionOnScriptError(false)
+
 def baseUrl = 'https://services.gradle.org'
 HtmlPage p = wc.getPage(baseUrl + '/distributions');
 


### PR DESCRIPTION
Because the following errors occurred.

```
$ groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy gradle.groovy
loading dependencies...done
Caught: com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: TypeError: Expected argument of type object, but instead had type object (https://fast.wistia.com/static/embed_shepherd-v1.js#547) (gradle.groovy#10) (gradle.groovy#10) (gradle.groovy#10)
======= EXCEPTION START ========
Exception class=[net.sourceforge.htmlunit.corejs.javascript.WrappedException]
com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: Wrapped com.gargoylesoftware.htmlunit.ScriptException: TypeError: Expected argument of type object, but instead had type object (https://fast.wistia.com/static/embed_shepherd-v1.js#547) (gradle.groovy#10) (gradle.groovy#10) (gradle.groovy#10)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine$HtmlUnitContextAction.run(JavaScriptEngine.java:528)
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:529)
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:536)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.callFunction(JavaScriptEngine.java:458)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.executeJavaScriptFunctionIfPossible(HtmlPage.java:918)
	at com.gargoylesoftware.htmlunit.javascript.host.EventListenersContainer.executeEventListeners(EventListenersContainer.java:155)
	at com.gargoylesoftware.htmlunit.javascript.host.EventListenersContainer.executeBubblingListeners(EventListenersContainer.java:207)
	at com.gargoylesoftware.htmlunit.javascript.host.Node.fireEvent(Node.java:619)
	at com.gargoylesoftware.htmlunit.html.HtmlElement$2.run(HtmlElement.java:886)
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:529)
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:536)
	at com.gargoylesoftware.htmlunit.html.HtmlElement.fireEvent(HtmlElement.java:891)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.executeEventHandlersIfNeeded(HtmlPage.java:1133)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.initialize(HtmlPage.java:177)
	at com.gargoylesoftware.htmlunit.WebClient.loadWebResponseInto(WebClient.java:456)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:332)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:389)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:374)
	at com.gargoylesoftware.htmlunit.WebClient$getPage.call(Unknown Source)
	at gradle.run(gradle.groovy:10)
	at runner$_run_closure1.doCall(runner.groovy:13)
	at runner.run(runner.groovy:10)

...

== CALLING JAVASCRIPT ==

  function async_load() {
      var s = document.createElement("script");
      s.type = "text/javascript";
      s.src = ("https:" == document.location.protocol ? "https://pi" : "http://cdn") + ".pardot.com/pd.js";
      var c = document.getElementsByTagName("script")[0];
      c.parentNode.insertBefore(s, c);
  }

======= EXCEPTION END ========
```