### PR TITLE
Update crawler to list scanner for msbuild netcore

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -1,5 +1,5 @@
 #!./lib/runner.groovy
-// Generates server-side metadata for SonarQube Scanner for MSBuild
+// Generates server-side metadata for SonarScanner for MSBuild
 import net.sf.json.*
 
 def url = "https://api.github.com/repos/SonarSource/sonar-scanner-msbuild/releases".toURL()
@@ -10,19 +10,27 @@ def json = []
 for (JSONObject release : releases) {
   def tagName = release.get("tag_name")
   if (!release.get("draft") && !release.get("prerelease") && !tagName.toLowerCase().contains("vsts")) {
-    def fileName
+
     if (tagName.startsWith("1") || tagName.equals("2.0") || tagName.equals("2.1")) {
-      fileName = "MSBuild.SonarQube.Runner-${tagName}.zip"
+       json << ["id": tagName,
+              "name": "SonarScanner for MSBuild ${tagName}".toString(),
+              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/MSBuild.SonarQube.Runner-${tagName}.zip".toString()];
+
     } else if (tagName.startsWith("2.") || tagName.startsWith("3.") || tagName.startsWith("4.0.")) {
-      fileName = "sonar-scanner-msbuild-${tagName}.zip"
+      json << ["id": tagName,
+              "name": "SonarScanner for MSBuild ${tagName}".toString(),
+              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}.zip".toString()];
+
     } else {
-      fileName = "sonar-scanner-msbuild-${tagName}-net46.zip"
+      json << ["id": tagName,
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 4.6".toString(),
+             "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net46.zip".toString()];
+
+      json << ["id": "${tagName}-netcore".toString(),
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Core 2.0".toString(),
+             "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-netcoreapp2.0.zip".toString()];
     }
-    json << ["id": tagName,
-             "name": "SonarQube Scanner for MSBuild ${tagName}".toString(), 
-             "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/${fileName}".toString()];
   }
 }
 
 lib.DataWriter.write("hudson.plugins.sonar.MsBuildSonarQubeRunnerInstaller",JSONObject.fromObject([list:json]));
-


### PR DESCRIPTION
Hi,

Sorry for this missed 1st PR.

We are currently working on our [Jenkins plugin](https://github.com/SonarSource/sonar-scanner-jenkins) to provide the ability for our end-users to user the .net core version of one of our product (scanner for msbuild). As part of this change we needed to update the crawler so that the users can select the scanner for .net core in the drop-down of the plugin configuration.

I put a `[do not merge]` in the title because we would like to be able to synchronize the release of our plugin with the availability of the new scanners in the drop-down to avoid (reduce is more appropriate) the number of support request we would/could receive from users.

Cheers,
Amaury