### PR TITLE
Restore JDK runner

### DIFF
--- a/jdk.groovy
+++ b/jdk.groovy
@@ -28,8 +28,8 @@ public class ListJDK {
         return new JSONObject()
                 .element("version", 2)
                 .element("data", new JSONArray()
-                        .element(family("JDK 10",
-                            parse("http://www.oracle.com/technetwork/java/javase/downloads/jdk10-downloads-4416644.html")))
+//                        .element(family("JDK 10",
+//                            parse("http://www.oracle.com/technetwork/java/javase/downloads/jdk10-downloads-4416644.html")))
                         .element(family("JDK 9", combine(
                             parse("http://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase9-3934878.html"))))
                         .element(family("JDK 8", combine(


### PR DESCRIPTION
Will lose JDK 10 but, as Oracle helpfully informs us,
"Java SE 10 has reached end of support. Users of Java SE 10 should switch to Java SE 11."