### PR TITLE
[FIXED JENKINS-62887] Fix for updated Go download page

### DIFF
--- a/golang.groovy
+++ b/golang.groovy
@@ -6,7 +6,7 @@ import com.gargoylesoftware.htmlunit.WebClient
 import net.sf.json.*
 
 // Fetch the list of downloads from the Go website
-def downloadsUrl = "http://golang.org/dl/"
+def downloadsUrl = "https://golang.org/dl/"
 
 // Gather a list of URLs
 def urls = []
@@ -43,7 +43,7 @@ urls.each { url ->
 
     // Gather the info for this archive
     def variant = [:]
-    variant.url = url
+    variant.url = "https://golang.org" + url
     variant.os = parts[0][2]
     variant.arch = parts[0][3]
     if (parts[0][4] && parts[0][4].startsWith("osx")) {


### PR DESCRIPTION
Ticket: https://issues.jenkins-ci.org/browse/JENKINS-62887

The links provided on the download page no longer provide the absolute URL, so we need to add the prefix ourselves.

I ran the crawler and checked a bunch of the URLs — they looked fine.