### PR TITLE
Add support for .NET5

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -25,6 +25,10 @@ for (JSONObject release : releases) {
       json << ["id": tagName,
              "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 4.6".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net46.zip".toString()];
+      
+      json << ["id": tagName,
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 5.0".toString(),
+             "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net5.0.zip".toString()];
 
       json << ["id": "${tagName}-netcore".toString(),
              "name": "SonarScanner for MSBuild ${tagName} - .NET Core 2.0".toString(),


### PR DESCRIPTION
Since the MSBuild sonar scanner release 5 (https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/5.0.0.23533) there is now officially support for .NET5 included in the releases. The crawler currently does not pick up or propagate the availability of .NET5 since it is not included in this groovy config. Adding the functionality here ensures the crawler publishes the availability of the new framework.

Separately, there may be a need to reconsider/refactor how the crawler works to take into account the changing nature of of framework version support coming from the sonar scanner for msbuild, so that manual updates and PRs like this aren't required each time there is a new .NET version.