### PR TITLE
Update groovy binaries location

### DIFF
--- a/groovy.groovy
+++ b/groovy.groovy
@@ -6,7 +6,7 @@ import net.sf.json.*
 import com.gargoylesoftware.htmlunit.WebClient
 
 def wc = new WebClient()
-def baseUrl = 'https://dl.bintray.com/groovy/maven/'
+def baseUrl = 'https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/'
 HtmlPage p = wc.getPage(baseUrl);
 
 def json = [];


### PR DESCRIPTION
With Bintray going away, the Groovy team is hosting the zip distributions in https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/ now (https://twitter.com/paulk_asert/status/1382103222446292996?s=20)