### PR TITLE
Stop stripping first char from filename

### DIFF
--- a/groovy.groovy
+++ b/groovy.groovy
@@ -12,7 +12,7 @@ HtmlPage p = wc.getPage(baseUrl);
 def json = [];
 
 p.getByXPath("//a[@href]").reverse().collect { HtmlAnchor e ->
-    def url = baseUrl + e.getHrefAttribute()[1..-1]
+    def url = baseUrl + e.getHrefAttribute()
     println url
     def m = (url =~ /groovy-binary-(\d.\d.\d).zip$/)
     if (m) {


### PR DESCRIPTION
Bintray used to have a colon (':') prepended to the filename in the href attribute. This is no longer the case when we are using
the new mirror.

New mirror (https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/)
<img width="370" alt="Screenshot 2021-04-14 at 13 59 03" src="https://user-images.githubusercontent.com/15606289/114707883-05b78580-9d2b-11eb-8865-2f23f7270ca4.png">

Old mirror (https://dl.bintray.com/groovy/maven/)
<img width="370" alt="Screenshot 2021-04-14 at 13 58 49" src="https://user-images.githubusercontent.com/15606289/114707890-06e8b280-9d2b-11eb-9c82-7d5d9cf9db27.png">
