### PR TITLE
Use "tag_name" instead of "name"

### DIFF
--- a/dependencycheck.groovy
+++ b/dependencycheck.groovy
@@ -21,7 +21,7 @@ def listFromGithub() {
 
     releases.collect {
         release ->
-            def version = release["name"].substring(1)
+            def version = release["tag_name"].substring(1)
             ["id": version,
              "name": "dependency-check ${version}".toString(),
              "url": "https://github.com/jeremylong/DependencyCheck/releases/download/v${version}/dependency-check-${version}-release.zip".toString()]


### PR DESCRIPTION
Starting with 6.0.4, the "name" value switched from "vX" to "Version X" while the "tag_name" value has remained consistent and in the expected format.