### PR TITLE
Fixed duplicate id for sonar-scanner-msbuild versions

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -25,9 +25,9 @@ for (JSONObject release : releases) {
       json << ["id": tagName,
              "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 4.6".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net46.zip".toString()];
-      
-      json << ["id": tagName,
-             "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 5.0".toString(),
+
+      json << ["id": "${tagName}-net5".toString(),
+             "name": "SonarScanner for MSBuild ${tagName} - .NET 5.0".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net5.0.zip".toString()];
 
       json << ["id": "${tagName}-netcore".toString(),


### PR DESCRIPTION
The PR supplied in #96 uses the same ID for two different versions. I'm actually curious how the initial PR ever worked, but it doesn't do so now.

I added a unique ID for the net5.0 version, which should fix this.

I also changed the display name to better reflect the official name of .NET 5.0 which MS promotes for it.