### PR TITLE
Limit number of releases for Scanner for MSBuild (.NET)

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -9,7 +9,7 @@ def json = []
 
 def maxNumberOfReleases = 2
   
-for (i = 0; i < maxNumberOfReleases - 1; i++) {
+for (i = 0; i <= maxNumberOfReleases - 1; i++) {
   JSONObject release = releases[i]
   def tagName = release.get("tag_name")
   if (!release.get("draft") && !release.get("prerelease") && !tagName.toLowerCase().contains("vsts")) {


### PR DESCRIPTION
- Cleanup old code for old releases
- Limit number of releases to 2
- Changed naming to Scanner for .NET as per our new name.