### PR TITLE
Revert "Limit number of releases for Scanner for MSBuild (.NET) (#108)"

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -7,28 +7,37 @@ def releases = JSONArray.fromObject(url.text)
 
 def json = []
 
-def maxNumberOfReleases = 2
-  
-for (i = 0; i <= maxNumberOfReleases - 1; i++) {
-  JSONObject release = releases[i]
+for (JSONObject release : releases) {
   def tagName = release.get("tag_name")
   if (!release.get("draft") && !release.get("prerelease") && !tagName.toLowerCase().contains("vsts")) {
-    
+
+    if (tagName.startsWith("1") || tagName.equals("2.0") || tagName.equals("2.1")) {
+       json << ["id": tagName,
+              "name": "SonarScanner for MSBuild ${tagName}".toString(),
+              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/MSBuild.SonarQube.Runner-${tagName}.zip".toString()];
+
+    } else if (tagName.startsWith("2.") || tagName.startsWith("3.") || tagName.startsWith("4.0.")) {
       json << ["id": tagName,
-             "name": "SonarScanner for .NET ${tagName} - .NET Fwk 4.6".toString(),
+              "name": "SonarScanner for MSBuild ${tagName}".toString(),
+              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}.zip".toString()];
+
+    } else {
+      json << ["id": tagName,
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Fwk 4.6".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net46.zip".toString()];
 
       json << ["id": "${tagName}-net5".toString(),
-             "name": "SonarScanner for .NET ${tagName} - .NET 5.0".toString(),
+             "name": "SonarScanner for MSBuild ${tagName} - .NET 5.0".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-net5.0.zip".toString()];
 
       json << ["id": "${tagName}-netcore".toString(),
-             "name": "SonarScanner for .NET ${tagName} - .NET Core 2.0".toString(),
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Core 2.0".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-netcoreapp2.0.zip".toString()];
 
       json << ["id": "${tagName}-netcore3".toString(),
-             "name": "SonarScanner for .NET ${tagName} - .NET Core 3.0".toString(),
+             "name": "SonarScanner for MSBuild ${tagName} - .NET Core 3.0".toString(),
              "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/sonar-scanner-msbuild-${tagName}-netcoreapp3.0.zip".toString()];
+    }
   }
 }
 


### PR DESCRIPTION
This reverts commit daae8077811508152b8ecbe9988648102a2286c1, introduced with https://github.com/jenkins-infra/crawler/pull/108.

The impact wasn't thought through. We apologize for the inconvenience, and for breaking some setups. This will get us back to a working state again.