### PR TITLE
JENKINS-68486 - Hashicorp plugins unable to download releases

### DIFF
--- a/consul.groovy
+++ b/consul.groovy
@@ -13,7 +13,7 @@ p.getByXPath("//a[@href]").grep { it.hrefAttribute =~ /\/consul\/.*/ }.each {
         def m = (it.textContent =~ /consul_.*(\d+.\d+.\d+)_(.*)_(.*).zip/)
         if (m) {
             def verId = "${m[0][1]}-${m[0][2]}-${m[0][3]}".toString()
-            json << ["id": verId, "name": "Consul ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${baseUrl}${it.hrefAttribute}".toString()];
+            json << ["id": verId, "name": "Consul ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${it.hrefAttribute}".toString()];
         }
     }
 }

--- a/packer.groovy
+++ b/packer.groovy
@@ -13,7 +13,7 @@ p.getByXPath("//a[@href]").grep { it.hrefAttribute =~ /\/packer\/.*/ }.each {
         def m = (it.textContent =~ /packer_.*(\d+.\d+.\d+)_(.*)_(.*).zip/)
         if (m) {
             def verId = "${m[0][1]}-${m[0][2]}-${m[0][3]}".toString()
-            json << ["id": verId, "name": "Packer ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${baseUrl}${it.hrefAttribute}".toString()];
+            json << ["id": verId, "name": "Packer ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${it.hrefAttribute}".toString()];
         }
     }
 }

--- a/terraform.groovy
+++ b/terraform.groovy
@@ -12,7 +12,7 @@ p.getByXPath("//a[@href]").grep { it.hrefAttribute =~ /\/terraform\/.*/ }.each {
         def m = (it.textContent =~ /terraform.*(\d+.\d+.\d+)_(.*)_(.*).zip/)
         if (m) {
             def verId = "${m[0][1]}-${m[0][2]}-${m[0][3]}".toString()
-            json << ["id": verId, "name": "Terraform ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${baseUrl}${it.hrefAttribute}".toString()];
+            json << ["id": verId, "name": "Terraform ${m[0][1]} ${m[0][2]} (${m[0][3]})".toString(), "url": "${it.hrefAttribute}".toString()];
         }
     }
 }


### PR DESCRIPTION
Remove the base URL prefix that is being added to the URLs for Hashicorp tools from https://releases.hashicorp.com
It appears that the release page used to have relative URLs, but a recent change (apparently in line with https://www.hashicorp.com/blog/announcing-the-hashicorp-releases-api) has caused the URLs to be absolute