### PR TITLE
Replace core dependency with version number lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>1.409</version>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
ref https://github.com/jenkins-infra/crawler/pull/110

from a quick code search I think it's just the version number dependency which is coming from the old core version.

Hard to tell though because it's groovy it could be relying on other deps