### PR TITLE
fix: set a user agent for the hlmtunit.WebClient to get the unredirected groovy versions page

### DIFF
--- a/groovy.groovy
+++ b/groovy.groovy
@@ -4,8 +4,20 @@ import com.gargoylesoftware.htmlunit.html.*;
 
 import net.sf.json.*
 import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.BrowserVersion
 
-def wc = new WebClient()
+final String applicationName = "APPNAME";
+final String applicationVersion = "APPVERSION";
+final String userAgent = "USERAGENT";
+
+final BrowserVersion browser =
+        new BrowserVersion.BrowserVersionBuilder(BrowserVersion.BEST_SUPPORTED)
+            .setApplicationName(applicationName)
+            .setApplicationVersion(applicationVersion)
+            .setUserAgent(userAgent)
+            .build();
+
+def wc = new WebClient(browser);
 def baseUrl = 'https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/'
 HtmlPage p = wc.getPage(baseUrl);
 


### PR DESCRIPTION
Without it, the web client call is redirected from https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/ (HTML page without any JS script) to https://groovy.jfrog.io/ui/native/dist-release-local/groovy-zips/, which contains a script https://groovy.jfrog.io/ui/externals/systemjs/dist/s.min.js with a `fetch` instruction unrecognized by htmlunit v2.36.0

As `curl https://groovy.jfrog.io/ui/native/dist-release-local/groovy-zips/` retrieved the pure HTML page, I've modified the browser profile so the server wouldn't not try to redirect the web client to the HTML and JS page.

---
I tried to update htmlunit to v2.59.0 ([which contains a polyfill](https://github.com/HtmlUnit/htmlunit/issues/78#issuecomment-1064829697) to fix the `fetch` error) in the init script, but then I've encountered this error:
```
loading dependencies...org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/Users/hervelemeur/cloudbees/j-infra/crawler/lib/init.groovy: 17: Apparent variable 'com' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:
You attempted to reference a variable in the binding or an instance variable from a static context.
You misspelled a classname or statically imported field. Please check the spelling.
You attempted to use a method 'com' but left out brackets in a place not allowed by the grammar.
 @ line 17, column 15.
           which com.gargoylesoftware.htmlunit.html.HTMLParser.class
```
Any tip how to fix this?

---
Part of https://github.com/jenkins-infra/helpdesk/issues/2950