### PR TITLE
fix(codeql.groovy): don't try to convert bundle name as integer

### DIFF
--- a/codeql.groovy
+++ b/codeql.groovy
@@ -32,10 +32,6 @@ data.each { release ->
     }
     def bundleDate = (tagname =~ /codeql-bundle-(.*)/)[0][1]
 
-    if(bundleDate.toInteger() < 20200826) {
-        return
-    }
-
     def bundleversion = ( release.body =~ /.*v([0-9]+\.[0-9]+\..*)/)[0][1]
 
     r.put("id", bundleversion )


### PR DESCRIPTION
[The `v2.6.0-beta.1` release](https://github.com/github/codeql-action/releases/tag/codeql-bundle-v2.6.0-beta.1) (published on 2021-07-27, 3 days after the implementation of this particular crawler 😅) has a different download URL pattern than the other, and throw an error on [the cast to integer filtering out older versions than 2020-08-26](https://github.com/jenkins-infra/crawler/blob/4cd93e6b52475696e5f4d16e389f4e1da3353522/codeql.groovy).

While [the GitHub releases page](https://github.com/github/codeql-action/releases?page=5) returns older releases, [the GitHub API](https://api.github.com/repos/github/codeql-action/releases) used in the script returns only the releases created [on the 2021-05-03](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20210503) or after.
I don't think fhe filter isn't needed any more, I can add it back while taking care of the `v2.6.0-beta.1` exception if needed.

Fixes https://github.com/jenkins-infra/crawler/issues/122
Fix one of the failing scripts noticed in https://github.com/jenkins-infra/helpdesk/issues/2950
