### PR TITLE
[JENKINS-66455] Migrate to `api.adoptium.net`

### DIFF
--- a/adoptopenjdk.groovy
+++ b/adoptopenjdk.groovy
@@ -8,7 +8,7 @@ import net.sf.json.JSONObject
 class ListAdoptOpenJDK {
     private final WebClient wc;
 
-    private final String API_URL = "https://api.adoptopenjdk.net/v3";
+    private final String API_URL = "https://api.adoptium.net/v3";
 
     ListAdoptOpenJDK() {
         wc = new WebClient();
@@ -33,7 +33,6 @@ class ListAdoptOpenJDK {
         JSONObject data = JSONObject.fromObject(response.getContentAsString())
 
         result.addAll(getReleases(data.available_releases as JSONArray, "HotSpot"))
-        result.addAll(getReleases(data.available_releases as JSONArray, "OpenJ9"))
 
         return new JSONObject()
                 .element("version", 2)
@@ -50,7 +49,7 @@ class ListAdoptOpenJDK {
             int page = 0
             boolean keepGoing = true
             while (keepGoing) {
-                Page a = wc.getPage(API_URL + "/assets/feature_releases/" + feature_version + "/ga?vendor=adoptopenjdk&project=jdk&image_type=jdk&sort_method=DEFAULT&sort_order=DESC&page_size=20&page=" + (page++) + "&jvm_impl=" + openjdk_impl)
+                Page a = wc.getPage(API_URL + "/assets/feature_releases/" + feature_version + "/ga?vendor=eclipse&project=jdk&image_type=jdk&sort_method=DEFAULT&sort_order=DESC&page_size=20&page=" + (page++) + "&jvm_impl=" + openjdk_impl)
                 WebResponse ar = a.getWebResponse()
                 if (ar.getStatusCode() == 200) {
                     JSONArray assets = JSONArray.fromObject(ar.getContentAsString())


### PR DESCRIPTION
Adapts [as instructed here](https://api.adoptopenjdk.net) by following the [migration guide](https://api.adoptopenjdk.net/migration.html); namely, by noting that there is now only one `vendor` (`eclipse`) and one `jvm_impl` (`hotspot`). I did not bump https://github.com/jenkins-infra/crawler/blob/f065c6afb641dd49e3443313888315d4e623f3a8/adoptopenjdk.groovy#L39 because the format of the JSON being returned is the same as before; it just has fewer elements now that we are using `api.adoptium.net`, which no longer returns Java 9, 10, 12, 13, 14, 15, or 16 and OpenJ9. I tested this by running the code locally and comparing the JSON before and after, noting that the new JSON was in the same format of the old and was a strict subset of the JDKs returned by the old JSON, which was the expected result given the abovementioned removals.