### PR TITLE
dotnetSdk: Update handling for JSON content changes

### DIFF
--- a/dotnetSdk.groovy
+++ b/dotnetSdk.groovy
@@ -266,6 +266,7 @@ private void createSdkDownloads() {
         def version = [:]
         version['name'] = v.getString('product') + ' ' + v.getString('channel-version')
         version['status'] = v.getString('support-phase').toUpperCase()
+        version['type'] = v.getString('release-type').toUpperCase()
         version['endOfSupport'] = v.get('eol-date')
         def releases = []
         final JSONObject channel = fetchJson(v.getString('releases.json'))


### PR DESCRIPTION
The support status (short-term vs long-term) is now in a separate `release-type` field in the Microsoft-supplied JSON data, with `support-phase` set to `active` instead of `current` or `lts` like before.

That release type is now retained as a `type` field in the output JSON data.