### PR TITLE
Adjust GitHub URLs to use https

### DIFF
--- a/scriptler.groovy
+++ b/scriptler.groovy
@@ -10,7 +10,7 @@ if (dir.isDirectory() && new File(dir, ".git").isDirectory()) {
     "git pull --rebase origin master".execute([], dir).waitFor()
 } else {
      dir.mkdirs()
-    "git clone git://github.com/jenkinsci/jenkins-scripts -b master".execute().waitFor()
+    "git clone https://github.com/jenkinsci/jenkins-scripts -b master".execute().waitFor()
 }
 
 def scriptlerDir = new File(dir, "scriptler")


### PR DESCRIPTION
The unencrypted git protocol was dropped by GitHub on 2022-03-15.

Fixes #123.