### PR TITLE
Add Maven Central to Grape configuration

### DIFF
--- a/grapeConfig.xml
+++ b/grapeConfig.xml
@@ -10,6 +10,7 @@
       <!--ibiblio name="codehaus" root="http://repository.codehaus.org/" m2compatible="true"/-->
       <!--ibiblio name="ibiblio" m2compatible="true"/-->
       <ibiblio name="m.g.o-public" root="https://repo.jenkins-ci.org/public/" m2compatible="true" />
+      <ibiblio name="central" m2compatible="true" />
     </chain>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
Unlike Maven, Grape/Ivy don't add this automatically.

CC @MarkEWaite

### Testing done

`groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy adoptopenjdk.groovy`