### PR TITLE
[sonarqubescannermsbuild.groovy] Added explicit page size to prevent missing releases in the result

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -2,7 +2,7 @@
 // Generates server-side metadata for SonarScanner for MSBuild
 import net.sf.json.*
 
-def url = "https://api.github.com/repos/SonarSource/sonar-scanner-msbuild/releases".toURL()
+def url = "https://api.github.com/repos/SonarSource/sonar-scanner-msbuild/releases?per_page=100".toURL()
 def releases = JSONArray.fromObject(url.text)
 
 def json = []


### PR DESCRIPTION
Added per_page URL parameter as quick fix because versions are currently missing in the Jenkins tools settings page.

Default value is 30 and current amount of releases is 77.