### PR TITLE
chore: use short-lived SAS token to sync updates-jenkins-io File Share

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,12 @@ node('linux') {
                 sh 'rsync -avz  -e \'ssh -o StrictHostKeyChecking=no\' --exclude=.svn updates/ www-data@updates.jenkins.io:/var/www/updates.jenkins.io/updates/'
             }
             withCredentials([
+                azureServicePrincipal(
+                    credentialsId: 'trusted_ci_jenkins_io_fileshare_serviceprincipal_writer',
+                    clientIdVariable : 'JENKINS_INFRA_FILESHARE_CLIENT_ID',
+                    clientSecretVariable : 'JENKINS_INFRA_FILESHARE_CLIENT_SECRET',
+                    tenantIdVariable : 'JENKINS_INFRA_FILESHARE_TENANT_ID' 
+                ),
                 string(credentialsId: 'updates-jenkins-io-file-share-sas-token-query-string', variable: 'UPDATES_FILE_SHARE_QUERY_STRING'),
                 string(credentialsId: 'aws-access-key-id-updatesjenkinsio', variable: 'AWS_ACCESS_KEY_ID'),
                 string(credentialsId: 'aws-secret-access-key-updatesjenkinsio', variable: 'AWS_SECRET_ACCESS_KEY')
@@ -78,9 +84,15 @@ node('linux') {
                     'AWS_DEFAULT_REGION=auto',
                     'UPDATES_R2_BUCKETS=westeurope-updates-jenkins-io',
                     'UPDATES_R2_ENDPOINT=https://8d1838a43923148c5cee18ccc356a594.r2.cloudflarestorage.com',
+                    'STORAGE_FILESHARE=updates-jenkins-io',
+                    'STORAGE_NAME=updatesjenkinsio',
+                    'STORAGE_DURATION_IN_MINUTE=5',
+                    'STORAGE_PERMISSIONS=dlrw'
                 ]) {
                     sh '''
-                    azcopy sync ./updates/ "https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io/updates/?${UPDATES_FILE_SHARE_QUERY_STRING}" --exclude-path '.svn' --recursive=true
+                    # Source of this script: https://github.com/jenkins-infra/pipeline-library/tree/master/resources/get-fileshare-signed-url.sh
+                    fileShareSignedUrl=$(get-fileshare-signed-url.sh)
+                    azcopy sync ./updates/ "${fileShareSignedUrl}" --exclude-path '.svn' --recursive=true
 
                     ## Note: AWS CLI are configured through environment variables (from Jenkins credentials) - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
                     aws s3 sync ./updates/ s3://"${UPDATES_R2_BUCKETS}"/updates/ \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,9 @@ node('linux') {
                     'STORAGE_PERMISSIONS=dlrw'
                 ]) {
                     sh '''
+                    # Don't print any command
+                    set +x
+
                     # Source of this script: https://github.com/jenkins-infra/pipeline-library/tree/master/resources/get-fileshare-signed-url.sh
                     fileShareSignedUrl=$(get-fileshare-signed-url.sh)
                     azcopy sync ./updates/ "${fileShareSignedUrl}" --exclude-path '.svn' --recursive=true


### PR DESCRIPTION
This PR replaces the use of a long-lived SAS token by a short-lived one generated from a service principal via the get-fileshare-signed-url script from https://github.com/jenkins-infra/pipeline-library/blob/master/resources/get-fileshare-signed-url.sh

Needs:
- <del>https://github.com/jenkins-infra/jenkins-infra/pull/3323</del> (permanent agent)
- https://github.com/jenkins-infra/packer-images/pull/1084 (ephemeral agents)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1952035761
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1973817455