### PR TITLE
Merge JDK release binaries if it shares a release name

### DIFF
--- a/adoptopenjdk.groovy
+++ b/adoptopenjdk.groovy
@@ -61,7 +61,7 @@ class ListAdoptOpenJDK {
             if (ar.getStatusCode() == 200) {
                 JSONArray assets = JSONArray.fromObject(ar.getContentAsString())
                 assets.forEach { JSONObject asset -> releasesMap.merge(asset.release_name as String, asset, { v1, v2 ->
-                    if (v1.version_data?.adopt_build_number > v1.version_data?.adopt_build_number){
+                    if (v1.version_data?.adopt_build_number > v2.version_data?.adopt_build_number){
                         v1.binaries.addAll(v2.binaries);
                         return v1;
                     } else {


### PR DESCRIPTION
api.adoptium.net may respond with a duplicate release name if a new build was required [1]. In this case, adopt_build_number should be present and incremented.

> Note that they have different adopt_build_number, in effect openjdk_version to Adoptium releases are not 1:1 within the API, and therefore will be grouped into different release lists. As in this case we might re-spin a release, this would modify the adopt_build_number but would map to the same openjdk_version since they are built from the same tag of the OpenJDK repo, and would map to the same version in the upstream project.

[1] https://github.com/adoptium/api.adoptium.net/issues/829

Should fix [JENKINS-72319](https://issues.jenkins.io/browse/JENKINS-72319) Unable to install JDK 21.0.

the current diff is

```bash
❯ rm -r target/
wget -q https://mirrors.jenkins-ci.org/updates/updates/io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json -O io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json
groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy adoptopenjdk.groovy > /dev/null
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/usr/share/groovy/lib/groovy-2.4.21.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
❯ diff target/io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json 
3471a3472,3481
>           "binaries": [          {
>             "architecture": "x64",
>             "binary_link": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_windows_hotspot_21.0.1_12.zip",
>             "openjdk_impl": "hotspot",
>             "os": "windows"
>           }],
>           "openjdk_impl": "hotspot",
>           "release_name": "jdk-21.0.1+12"
>         },
>                 {
3514,3519d3523
<             },
<                         {
<               "architecture": "x64",
<               "binary_link": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_windows_hotspot_21.0.1_12.zip",
<               "openjdk_impl": "hotspot",
<               "os": "windows"
```
