### PR TITLE
cleanup: remove superseded credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,6 @@ node('linux') {
                     clientSecretVariable : 'JENKINS_INFRA_FILESHARE_CLIENT_SECRET',
                     tenantIdVariable : 'JENKINS_INFRA_FILESHARE_TENANT_ID' 
                 ),
-                string(credentialsId: 'updates-jenkins-io-file-share-sas-token-query-string', variable: 'UPDATES_FILE_SHARE_QUERY_STRING'),
                 string(credentialsId: 'aws-access-key-id-updatesjenkinsio', variable: 'AWS_ACCESS_KEY_ID'),
                 string(credentialsId: 'aws-secret-access-key-updatesjenkinsio', variable: 'AWS_SECRET_ACCESS_KEY')
             ]) {


### PR DESCRIPTION
This PR removes `updates-jenkins-io-file-share-sas-token-query-string` credentials from the pipeline, uperseded by the use of https://github.com/jenkins-infra/pipeline-library/blob/master/resources/get-fileshare-signed-url.sh to get the file share URL including a SAS token.

Verification procedure after merging this PR: ensure crawler job on trusted.ci.jenkins.io still passes.

Next step: delete the corresponding credentials from trusted.ci.jenkins.io

Follow-up of:
- #144 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-2034806598