### PR TITLE
chore(publish) fix AWS S3 copy errors by using checksum instead of size

### DIFF
--- a/.jenkins-scripts/publish.sh
+++ b/.jenkins-scripts/publish.sh
@@ -83,7 +83,6 @@ do
         --delete `# important: use relative path for destination otherwise you will delete update_center2 data from the bucket root` \
         --no-progress \
         --no-follow-symlinks \
-        --size-only \
         --exclude '.svn' \
         --endpoint-url "${BUCKET_ENDPOINT_URL}"
 done


### PR DESCRIPTION
Caught while working on https://github.com/jenkins-infra/helpdesk/issues/4373

Self merging