### PR TITLE
feat(publish): add archives.jenkins.io in the rsync process for update-center in crawler

### DIFF
--- a/.jenkins-scripts/publish.sh
+++ b/.jenkins-scripts/publish.sh
@@ -10,7 +10,7 @@ mkdir -p updates
 cp target/*.json target/*.html updates
 
 # Rsync sync tasks
-rsync_publish_tasks=("rsync-updates.jenkins.io" "rsync-updates.jenkins.io-data-content" "rsync-updates.jenkins.io-data-redirections-unsecured" "rsync-updates.jenkins.io-data-redirections-secured")
+rsync_publish_tasks=("rsync-updates.jenkins.io" "rsync-archives.jenkins.io" "rsync-updates.jenkins.io-data-content" "rsync-updates.jenkins.io-data-redirections-unsecured" "rsync-updates.jenkins.io-data-redirections-secured")
 
 for rsync_publish_task in "${rsync_publish_tasks[@]}"
 do


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4401
add archives.jenkins.io as a rsync destination to use it as a fallback mirror