### PR TITLE
chore(publish) stop copying tools metadatas to (aws.)updates.jenkins.io VM (also known as pkg)

### DIFF
--- a/.jenkins-scripts/publish.sh
+++ b/.jenkins-scripts/publish.sh
@@ -10,7 +10,7 @@ mkdir -p updates
 cp target/*.json target/*.html updates
 
 # Rsync sync tasks
-rsync_publish_tasks=("rsync-updates.jenkins.io" "rsync-archives.jenkins.io" "rsync-updates.jenkins.io-data-content" "rsync-updates.jenkins.io-data-redirections-unsecured" "rsync-updates.jenkins.io-data-redirections-secured")
+rsync_publish_tasks=("rsync-archives.jenkins.io" "rsync-updates.jenkins.io-data-content" "rsync-updates.jenkins.io-data-redirections-unsecured" "rsync-updates.jenkins.io-data-redirections-secured")
 
 for rsync_publish_task in "${rsync_publish_tasks[@]}"
 do


### PR DESCRIPTION
Ref. jenkins-infra/helpdesk#2649 (comment) and jenkins-infra/helpdesk#4610

This change stops copying tools installers to the `pkg` VM since it does not host any update center site anymore.