### PR TITLE
Restrict case intended for 1.X versions

### DIFF
--- a/sonarqubescannermsbuild.groovy
+++ b/sonarqubescannermsbuild.groovy
@@ -11,7 +11,7 @@ for (JSONObject release : releases) {
   def tagName = release.get("tag_name")
   if (!release.get("draft") && !release.get("prerelease") && !tagName.toLowerCase().contains("vsts")) {
 
-    if (tagName.startsWith("1") || tagName.equals("2.0") || tagName.equals("2.1")) {
+    if (tagName.startsWith("1.") || tagName.equals("2.0") || tagName.equals("2.1")) {
        json << ["id": tagName,
               "name": "SonarScanner for MSBuild ${tagName}".toString(),
               "url": "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/${tagName}/MSBuild.SonarQube.Runner-${tagName}.zip".toString()];


### PR DESCRIPTION
Fixes issue #162 where URLs generated for v10 of the SonarScanner for .NET tool were getting matched by the case intended for v1, resulting in invalid links.

Since the [SonarQube Scanner plugin](https://plugins.jenkins.io/sonar/) mentions the JSON files are updated on release of a new version, is there some additional step required to get the crawler script to run off-cycle?