### PR TITLE
Fix SBT tool installer download list generator

### DIFF
--- a/sbt.groovy
+++ b/sbt.groovy
@@ -20,7 +20,7 @@ def listFromMavenRepo() {
     HtmlPage p = wc.getPage(url);
     def pattern = Pattern.compile("^([0-9]+.*)/\$");
 
-    p.getAnchors().collect {
+    p.getAnchors().each {
         HtmlAnchor a ->
         def m = pattern.matcher(a.hrefAttribute)
         if (m.find()) {


### PR DESCRIPTION
## Fix SBT tool installer download list 

The sbt tool installer download previously read the Maven metadata file, then generated a list of GitHub download URLs without checking that the download URLs were functional.  Many of the download URLs were not usable.  Recent changes at Maven central have broken the previous technique.

Now it reads the hyperlinks on the page that lists the sbt versions, then generates a list of validated GitHub download URLs.  That is the same technique used by the flyway tool installer.

Issue first detected in plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/6225

Fixes the SBT plugin portion of Jira issue:

* https://issues.jenkins.io/browse/JENKINS-76355

Fixes the SBT plugin portion of help desk ticket:

* https://github.com/jenkins-infra/helpdesk/issues/4957

Testing done:

* Confirmed the list was empty before this change
* Confirmed that this change now lists available sbt installers
* Compared the last JSON file from the Wayback machine with the new file.  Old file included links to GitHub installers that would fail to download.  Old file was missing installers for 1.12.0, 1.11.7, 1.11.6, 1.11.5, and 1.11.4
