### PR TITLE
Fail if tool installers are empty

### DIFF
--- a/.jenkins-scripts/generate.sh
+++ b/.jenkins-scripts/generate.sh
@@ -9,9 +9,12 @@ then
   export JENKINS_SIGNER="-key \"$SECRET/update-center.key\" -certificate \"$SECRET/update-center.cert\" -root-certificate \"$SECRET/jenkins-update-center-root-ca.crt\""
 fi
 
-for f in *.groovy
+for f in [a-z]*.groovy
 do
     echo "= Crawler '$f':"
     groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy "$f" \
-      || true # Do not fail immediatly
+      || true # Hide failures and allow all generators to run
 done
+
+# Run a sanity test of the outputs
+groovy ZenithTest.groovy

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -12,8 +12,7 @@ import org.junit.Test;
  */
 class ZenithTest {
 
-    void checkFileSize(String fileName) {
-        long minimumSize = 500;
+    void checkFileSize(long minimumSize, String fileName) {
         File dataFile = new File("target/" + fileName);
         assertTrue("File target/" + fileName + " does not exist", dataFile.exists());
 
@@ -26,7 +25,7 @@ class ZenithTest {
 
     @Test
     void adoptopenjdk() {
-        checkFileSize("io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json");
+        checkFileSize(300_000L, "io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json");
     }
 
     // TODO: Enable after first run that provides non-empty data for Allure command line installer
@@ -38,72 +37,72 @@ class ZenithTest {
 
     @Test
     void ant() {
-        checkFileSize("hudson.tasks.Ant.AntInstaller.json");
+        checkFileSize(4_000L, "hudson.tasks.Ant.AntInstaller.json");
     }
 
     @Test
     void buckminster() {
-        checkFileSize("hudson.plugins.buckminster.BuckminsterInstallation.BuckminsterInstaller.json");
+        checkFileSize(4_000L, "hudson.plugins.buckminster.BuckminsterInstallation.BuckminsterInstaller.json");
     }
 
     @Test
     void chromedriver() {
-        checkFileSize("org.jenkins-ci.plugins.chromedriver.ChromeDriver.json");
+        checkFileSize(10_000L, "org.jenkins-ci.plugins.chromedriver.ChromeDriver.json");
     }
 
     @Test
     void cmake() {
-        checkFileSize("hudson.plugins.cmake.CmakeInstaller.json");
+        checkFileSize(200_000L, "hudson.plugins.cmake.CmakeInstaller.json");
     }
 
     @Test
     void codeql() {
-        checkFileSize("io.jenkins.plugins.codeql.CodeQLInstaller.json");
+        checkFileSize(400L, "io.jenkins.plugins.codeql.CodeQLInstaller.json");
     }
 
     @Test
     void consul() {
-        checkFileSize("com.inneractive.jenkins.plugins.consul.ConsulInstaller.json");
+        checkFileSize(400_000L, "com.inneractive.jenkins.plugins.consul.ConsulInstaller.json");
     }
 
     @Test
     void dependencycheck() {
-        checkFileSize("org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstaller.json");
+        checkFileSize(15_000L, "org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstaller.json");
     }
 
     @Test
     void dotnetSdk() {
-        checkFileSize("io.jenkins.plugins.dotnet.data.Downloads.json");
+        checkFileSize(90_000L, "io.jenkins.plugins.dotnet.data.Downloads.json");
     }
 
     @Test
     void flyway() {
-        checkFileSize("sp.sd.flywayrunner.installation.FlywayInstaller.json");
+        checkFileSize(15_000L, "sp.sd.flywayrunner.installation.FlywayInstaller.json");
     }
 
     @Test
     void golang() {
-        checkFileSize("org.jenkinsci.plugins.golang.GolangInstaller.json");
+        checkFileSize(600_000L, "org.jenkinsci.plugins.golang.GolangInstaller.json");
     }
 
     @Test
     void gradle() {
-        checkFileSize("hudson.plugins.gradle.GradleInstaller.json");
+        checkFileSize(60_000L, "hudson.plugins.gradle.GradleInstaller.json");
     }
 
     @Test
     void grails() {
-        checkFileSize("com.g2one.hudson.grails.GrailsInstaller.json");
+        checkFileSize(24_000L, "com.g2one.hudson.grails.GrailsInstaller.json");
     }
 
     @Test
     void groovy() {
-        checkFileSize("hudson.plugins.groovy.GroovyInstaller.json");
+        checkFileSize(20_000L, "hudson.plugins.groovy.GroovyInstaller.json");
     }
 
     @Test
     void jdk() {
-        checkFileSize("hudson.tools.JDKInstaller.json");
+        checkFileSize(400_000L, "hudson.tools.JDKInstaller.json");
     }
 
     // TODO: Fix the leiningen generator and stop ignoring this test
@@ -115,7 +114,7 @@ class ZenithTest {
 
     @Test
     void maven() {
-        checkFileSize("hudson.tasks.Maven.MavenInstaller.json");
+        checkFileSize(8_000L, "hudson.tasks.Maven.MavenInstaller.json");
     }
 
     // TODO: Fix the mongodb generator and stop ignoring this test
@@ -127,56 +126,56 @@ class ZenithTest {
 
     @Test
     void nodejs() {
-        checkFileSize("hudson.plugins.nodejs.tools.NodeJSInstaller.json");
+        checkFileSize(80_000L, "hudson.plugins.nodejs.tools.NodeJSInstaller.json");
     }
 
     @Test
     void packer() {
-        checkFileSize("biz.neustar.jenkins.plugins.packer.PackerInstaller.json");
+        checkFileSize(300_000L, "biz.neustar.jenkins.plugins.packer.PackerInstaller.json");
     }
 
     @Test
     void play() {
-        checkFileSize("hudson.plugins.play.PlayInstaller.json");
+        checkFileSize(8_000L, "hudson.plugins.play.PlayInstaller.json");
     }
 
     @Test
     void recipe() {
-        checkFileSize("org.jenkinsci.plugins.recipe.RecipeCatalog.json");
+        checkFileSize(2_000L, "org.jenkinsci.plugins.recipe.RecipeCatalog.json");
     }
 
     @Test
     void sbt() {
-        checkFileSize("org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller.json");
+        checkFileSize(10_000L, "org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller.json");
     }
 
     @Test
     void sbuild() {
-        checkFileSize("org.sbuild.jenkins.plugin.SBuildInstaller.json");
+        checkFileSize(2_000L, "org.sbuild.jenkins.plugin.SBuildInstaller.json");
     }
 
     @Test
     void scala() {
-        checkFileSize("hudson.plugins.scala.ScalaInstaller.json");
+        checkFileSize(10_000L, "hudson.plugins.scala.ScalaInstaller.json");
     }
 
     @Test
     void scriptler() {
-        checkFileSize("org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json");
+        checkFileSize(24_000L, "org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json");
     }
 
     @Test
     void sonarqubescanner() {
-        checkFileSize("hudson.plugins.sonar.SonarRunnerInstaller.json");
+        checkFileSize(8_000L, "hudson.plugins.sonar.SonarRunnerInstaller.json");
     }
 
     @Test
     void sonarqubescannermsbuild() {
-        checkFileSize("hudson.plugins.sonar.MsBuildSonarQubeRunnerInstaller.json");
+        checkFileSize(60_000L, "hudson.plugins.sonar.MsBuildSonarQubeRunnerInstaller.json");
     }
 
     @Test
     void terraform() {
-        checkFileSize("org.jenkinsci.plugins.terraform.TerraformInstaller.json");
+        checkFileSize(70_000L, "org.jenkinsci.plugins.terraform.TerraformInstaller.json");
     }
 }

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -1,9 +1,10 @@
 /* Test results of generators */
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Test to be run after all installer metadata has been generated.
@@ -14,12 +15,13 @@ class ZenithTest {
     void checkFileSize(String fileName) {
         long minimumSize = 500;
         File dataFile = new File("target/" + fileName);
-        assertTrue(dataFile.exists(), "File target/" + fileName + " does not exist");
+        assertTrue("File target/" + fileName + " does not exist", dataFile.exists());
 
         long actualSize = dataFile.length();
         assertTrue(
+                "Size of target/" + fileName + " was " + actualSize + ", less than minimum " + minimumSize,
                 actualSize > minimumSize,
-                "Size of target/" + fileName + " was " + actualSize + ", less than minimum " + minimumSize);
+                );
     }
 
     @Test
@@ -27,11 +29,12 @@ class ZenithTest {
         checkFileSize("io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json");
     }
 
-    // TODO: Uncomment after first run that provides non-empty data for Allure command line installer
-    // @Test
-    // void allure() {
-    //     checkFileSize("ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstaller.json");
-    // }
+    // TODO: Enable after first run that provides non-empty data for Allure command line installer
+    @Test
+    @Ignore
+    void allure() {
+        checkFileSize("ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstaller.json");
+    }
 
     @Test
     void ant() {
@@ -103,22 +106,24 @@ class ZenithTest {
         checkFileSize("hudson.tools.JDKInstaller.json");
     }
 
-    // TODO: Fix the leiningen generator and uncomment this test
-    // @Test
-    // void leiningen() {
-    //     checkFileSize("org.jenkins-ci.plugins.leiningen.LeinInstaller.json");
-    // }
+    // TODO: Fix the leiningen generator and stop ignoring this test
+    @Test
+    @Ignore
+    void leiningen() {
+        checkFileSize("org.jenkins-ci.plugins.leiningen.LeinInstaller.json");
+    }
 
     @Test
     void maven() {
         checkFileSize("hudson.tasks.Maven.MavenInstaller.json");
     }
 
-    // TODO: Fix the mongodb generator and uncomment this test
-    // @Test
-    // void mongodb() {
-    //     checkFileSize("org.jenkinsci.plugins.mongodb.MongoDBInstaller.json");
-    // }
+    // TODO: Fix the mongodb generator and stop ignoring this test
+    @Test
+    @Ignore
+    void mongodb() {
+        checkFileSize("org.jenkinsci.plugins.mongodb.MongoDBInstaller.json");
+    }
 
     @Test
     void nodejs() {

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -1,0 +1,177 @@
+/* Test results of generators */
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test to be run after all installer metadata has been generated.
+ * Sanity checks for the installer metadata.
+ */
+class ZenithTest {
+
+    void checkFileSize(String fileName) {
+        long minimumSize = 500;
+        File dataFile = new File("target/" + fileName);
+        assertTrue(dataFile.exists(), "File target/" + fileName + " does not exist");
+
+        long actualSize = dataFile.length();
+        assertTrue(
+                actualSize > minimumSize,
+                "Size of target/" + fileName + " was " + actualSize + ", less than minimum " + minimumSize);
+    }
+
+    @Test
+    void adoptopenjdk() {
+        checkFileSize("io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.json");
+    }
+
+    // TODO: Uncomment after first run that provides non-empty data for Allure command line installer
+    // @Test
+    // void allure() {
+    //     checkFileSize("ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstaller.json");
+    // }
+
+    @Test
+    void ant() {
+        checkFileSize("hudson.tasks.Ant.AntInstaller.json");
+    }
+
+    @Test
+    void buckminster() {
+        checkFileSize("hudson.plugins.buckminster.BuckminsterInstallation.BuckminsterInstaller.json");
+    }
+
+    @Test
+    void chromedriver() {
+        checkFileSize("org.jenkins-ci.plugins.chromedriver.ChromeDriver.json");
+    }
+
+    @Test
+    void cmake() {
+        checkFileSize("hudson.plugins.cmake.CmakeInstaller.json");
+    }
+
+    @Test
+    void codeql() {
+        checkFileSize("io.jenkins.plugins.codeql.CodeQLInstaller.json");
+    }
+
+    @Test
+    void consul() {
+        checkFileSize("com.inneractive.jenkins.plugins.consul.ConsulInstaller.json");
+    }
+
+    @Test
+    void dependencycheck() {
+        checkFileSize("org.jenkinsci.plugins.DependencyCheck.tools.DependencyCheckInstaller.json");
+    }
+
+    @Test
+    void dotnetSdk() {
+        checkFileSize("io.jenkins.plugins.dotnet.data.Downloads.json");
+    }
+
+    @Test
+    void flyway() {
+        checkFileSize("sp.sd.flywayrunner.installation.FlywayInstaller.json");
+    }
+
+    @Test
+    void golang() {
+        checkFileSize("org.jenkinsci.plugins.golang.GolangInstaller.json");
+    }
+
+    @Test
+    void gradle() {
+        checkFileSize("hudson.plugins.gradle.GradleInstaller.json");
+    }
+
+    @Test
+    void grails() {
+        checkFileSize("com.g2one.hudson.grails.GrailsInstaller.json");
+    }
+
+    @Test
+    void groovy() {
+        checkFileSize("hudson.plugins.groovy.GroovyInstaller.json");
+    }
+
+    @Test
+    void jdk() {
+        checkFileSize("hudson.tools.JDKInstaller.json");
+    }
+
+    // TODO: Fix the leiningen generator and uncomment this test
+    // @Test
+    // void leiningen() {
+    //     checkFileSize("org.jenkins-ci.plugins.leiningen.LeinInstaller.json");
+    // }
+
+    @Test
+    void maven() {
+        checkFileSize("hudson.tasks.Maven.MavenInstaller.json");
+    }
+
+    // TODO: Fix the mongodb generator and uncomment this test
+    // @Test
+    // void mongodb() {
+    //     checkFileSize("org.jenkinsci.plugins.mongodb.MongoDBInstaller.json");
+    // }
+
+    @Test
+    void nodejs() {
+        checkFileSize("hudson.plugins.nodejs.tools.NodeJSInstaller.json");
+    }
+
+    @Test
+    void packer() {
+        checkFileSize("biz.neustar.jenkins.plugins.packer.PackerInstaller.json");
+    }
+
+    @Test
+    void play() {
+        checkFileSize("hudson.plugins.play.PlayInstaller.json");
+    }
+
+    @Test
+    void recipe() {
+        checkFileSize("org.jenkinsci.plugins.recipe.RecipeCatalog.json");
+    }
+
+    @Test
+    void sbt() {
+        checkFileSize("org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller.json");
+    }
+
+    @Test
+    void sbuild() {
+        checkFileSize("org.sbuild.jenkins.plugin.SBuildInstaller.json");
+    }
+
+    @Test
+    void scala() {
+        checkFileSize("hudson.plugins.scala.ScalaInstaller.json");
+    }
+
+    @Test
+    void scriptler() {
+        checkFileSize("org.jenkinsci.plugins.scriptler.CentralScriptJsonCatalog.json");
+    }
+
+    @Test
+    void sonarqubescanner() {
+        checkFileSize("hudson.plugins.sonar.SonarRunnerInstaller.json");
+    }
+
+    @Test
+    void sonarqubescannermsbuild() {
+        checkFileSize("hudson.plugins.sonar.MsBuildSonarQubeRunnerInstaller.json");
+    }
+
+    @Test
+    void terraform() {
+        checkFileSize("org.jenkinsci.plugins.terraform.TerraformInstaller.json");
+    }
+}

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -109,7 +109,7 @@ class ZenithTest {
     @Test
     @Ignore
     void leiningen() {
-        checkFileSize("org.jenkins-ci.plugins.leiningen.LeinInstaller.json");
+        checkFileSize(80L, "org.jenkins-ci.plugins.leiningen.LeinInstaller.json");
     }
 
     @Test
@@ -121,7 +121,7 @@ class ZenithTest {
     @Test
     @Ignore
     void mongodb() {
-        checkFileSize("org.jenkinsci.plugins.mongodb.MongoDBInstaller.json");
+        checkFileSize(80L, "org.jenkinsci.plugins.mongodb.MongoDBInstaller.json");
     }
 
     @Test

--- a/recipe.groovy
+++ b/recipe.groovy
@@ -2,6 +2,7 @@
 // generate metadata for recipes
 import net.sf.json.*
 import java.util.zip.*
+import groovy.xml.XmlSlurper
 
 def branch = "inbound";
 

--- a/recipe.groovy
+++ b/recipe.groovy
@@ -2,7 +2,6 @@
 // generate metadata for recipes
 import net.sf.json.*
 import java.util.zip.*
-import groovy.xml.XmlSlurper
 
 def branch = "inbound";
 


### PR DESCRIPTION
## Fail if tool installers are empty

Fixes issue:

* https://github.com/jenkins-infra/crawler/issues/166

Some of the generated data files no longer include content.  We didn't detect that because the script generator intentionally ignores failures from the generator scripts.  Test the output of the scripts to assure that there is some content in the generated files.

A few tests are still disabled because they are currently generating empty tool installer lists.  It is better to test a subset of the generated files than to test none of the generated files.

## Testing done

* Ran .jenkins-scripts/generate.sh and confirmed newly added tests all pass
