### PR TITLE
Fail Jenkins job on test failures and download errors

### DIFF
--- a/.jenkins-scripts/generate.sh
+++ b/.jenkins-scripts/generate.sh
@@ -12,8 +12,7 @@ fi
 for f in [a-z]*.groovy
 do
     echo "= Crawler '$f':"
-    groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy "$f" \
-      || true # Hide failures and allow all generators to run
+    groovy -Dgrape.config=./grapeConfig.xml ./lib/runner.groovy "$f"
 done
 
 # Run a sanity test of the outputs

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -185,6 +185,6 @@ class ZenithTest {
 
     @Test
     void terraform() {
-        checkFileSize(9_700_000L, "org.jenkinsci.plugins.terraform.TerraformInstaller.json");
+        checkFileSize(700_000L, "org.jenkinsci.plugins.terraform.TerraformInstaller.json");
     }
 }

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -4,13 +4,24 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
 
 /**
  * Test to be run after all installer metadata has been generated.
  * Sanity checks for the installer metadata.
  */
 class ZenithTest {
+
+    @Rule
+    public TestRule watchman = [failed: {e, d ->
+                println d
+                e.printStackTrace()
+                System.exit(1)
+                }
+        ] as TestWatcher; // System.exit(1) if any test fails
 
     void checkFileSize(long minimumSize, String fileName) {
         File dataFile = new File("target/" + fileName);
@@ -19,7 +30,7 @@ class ZenithTest {
         long actualSize = dataFile.length();
         assertTrue(
                 "Size of target/" + fileName + " was " + actualSize + ", less than minimum " + minimumSize,
-                actualSize > minimumSize,
+                actualSize >= minimumSize,
                 );
     }
 

--- a/ZenithTest.groovy
+++ b/ZenithTest.groovy
@@ -174,6 +174,6 @@ class ZenithTest {
 
     @Test
     void terraform() {
-        checkFileSize(70_000L, "org.jenkinsci.plugins.terraform.TerraformInstaller.json");
+        checkFileSize(9_700_000L, "org.jenkinsci.plugins.terraform.TerraformInstaller.json");
     }
 }


### PR DESCRIPTION
## Fail Jenkins job on test failures and download errors

Fixes https://github.com/jenkins-infra/helpdesk/issues/5039 by not allowing the trusted.ci.jenkins.io job to update the tool installer data if there is an error in downloading any of the data or if there is a test failure.

The ZenithTest.groovy file only checks the size of the files, not their content, but it is has been sufficient to detect cases where the Eclipse Temurin API was failing.
