### PR TITLE
Do not scrape Maven Central for tool releases

### DIFF
--- a/allure.groovy
+++ b/allure.groovy
@@ -7,6 +7,11 @@ import org.htmlunit.html.HtmlPage
 import java.util.regex.Pattern
 import net.sf.json.JSONObject
 
+// HACK HACK HACK HACK - https://github.com/jenkins-infra/crawler/issues/175 (phase 1)
+lib.DataWriter.write("ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstaller", JSONObject.fromObject(new File("allure.hack.json").text));
+System.exit(0)
+// End of HACK HACK HACK HACK
+
 def getList() {
     List versions = new ArrayList()
     versions.addAll(getCentralVersions())

--- a/allure.hack.json
+++ b/allure.hack.json
@@ -1,0 +1,372 @@
+{"list": [
+    {
+    "id": "2.40.0",
+    "name": "2.40.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.40.0/allure-commandline-2.40.0.zip"
+  },
+    {
+    "id": "2.39.0",
+    "name": "2.39.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.39.0/allure-commandline-2.39.0.zip"
+  },
+    {
+    "id": "2.38.1",
+    "name": "2.38.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.38.1/allure-commandline-2.38.1.zip"
+  },
+    {
+    "id": "2.38.0",
+    "name": "2.38.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.38.0/allure-commandline-2.38.0.zip"
+  },
+    {
+    "id": "2.37.0",
+    "name": "2.37.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.37.0/allure-commandline-2.37.0.zip"
+  },
+    {
+    "id": "2.36.0",
+    "name": "2.36.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.36.0/allure-commandline-2.36.0.zip"
+  },
+    {
+    "id": "2.35.1",
+    "name": "2.35.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.35.1/allure-commandline-2.35.1.zip"
+  },
+    {
+    "id": "2.35.0",
+    "name": "2.35.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.35.0/allure-commandline-2.35.0.zip"
+  },
+    {
+    "id": "2.34.1",
+    "name": "2.34.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.34.1/allure-commandline-2.34.1.zip"
+  },
+    {
+    "id": "2.34.0",
+    "name": "2.34.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.34.0/allure-commandline-2.34.0.zip"
+  },
+    {
+    "id": "2.33.0",
+    "name": "2.33.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.33.0/allure-commandline-2.33.0.zip"
+  },
+    {
+    "id": "2.32.2",
+    "name": "2.32.2",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.32.2/allure-commandline-2.32.2.zip"
+  },
+    {
+    "id": "2.32.0",
+    "name": "2.32.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.32.0/allure-commandline-2.32.0.zip"
+  },
+    {
+    "id": "2.31.0",
+    "name": "2.31.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.31.0/allure-commandline-2.31.0.zip"
+  },
+    {
+    "id": "2.30.0",
+    "name": "2.30.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.30.0/allure-commandline-2.30.0.zip"
+  },
+    {
+    "id": "2.29.0",
+    "name": "2.29.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.29.0/allure-commandline-2.29.0.zip"
+  },
+    {
+    "id": "2.28.0",
+    "name": "2.28.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.28.0/allure-commandline-2.28.0.zip"
+  },
+    {
+    "id": "2.27.0",
+    "name": "2.27.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.27.0/allure-commandline-2.27.0.zip"
+  },
+    {
+    "id": "2.26.0",
+    "name": "2.26.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.26.0/allure-commandline-2.26.0.zip"
+  },
+    {
+    "id": "2.25.0",
+    "name": "2.25.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.25.0/allure-commandline-2.25.0.zip"
+  },
+    {
+    "id": "2.24.1",
+    "name": "2.24.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.24.1/allure-commandline-2.24.1.zip"
+  },
+    {
+    "id": "2.24.0",
+    "name": "2.24.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.24.0/allure-commandline-2.24.0.zip"
+  },
+    {
+    "id": "2.23.1",
+    "name": "2.23.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.23.1/allure-commandline-2.23.1.zip"
+  },
+    {
+    "id": "2.23.0",
+    "name": "2.23.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.23.0/allure-commandline-2.23.0.zip"
+  },
+    {
+    "id": "2.22.4",
+    "name": "2.22.4",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.22.4/allure-commandline-2.22.4.zip"
+  },
+    {
+    "id": "2.22.3",
+    "name": "2.22.3",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.22.3/allure-commandline-2.22.3.zip"
+  },
+    {
+    "id": "2.22.2",
+    "name": "2.22.2",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.22.2/allure-commandline-2.22.2.zip"
+  },
+    {
+    "id": "2.22.1",
+    "name": "2.22.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.22.1/allure-commandline-2.22.1.zip"
+  },
+    {
+    "id": "2.22.0",
+    "name": "2.22.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.22.0/allure-commandline-2.22.0.zip"
+  },
+    {
+    "id": "2.21.0",
+    "name": "2.21.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.21.0/allure-commandline-2.21.0.zip"
+  },
+    {
+    "id": "2.20.1",
+    "name": "2.20.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.20.1/allure-commandline-2.20.1.zip"
+  },
+    {
+    "id": "2.20.0",
+    "name": "2.20.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.20.0/allure-commandline-2.20.0.zip"
+  },
+    {
+    "id": "2.19.0",
+    "name": "2.19.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.19.0/allure-commandline-2.19.0.zip"
+  },
+    {
+    "id": "2.18.1",
+    "name": "2.18.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.18.1/allure-commandline-2.18.1.zip"
+  },
+    {
+    "id": "2.18.0",
+    "name": "2.18.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.18.0/allure-commandline-2.18.0.zip"
+  },
+    {
+    "id": "2.17.3",
+    "name": "2.17.3",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.17.3/allure-commandline-2.17.3.zip"
+  },
+    {
+    "id": "2.17.2",
+    "name": "2.17.2",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.17.2/allure-commandline-2.17.2.zip"
+  },
+    {
+    "id": "2.17.1",
+    "name": "2.17.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.17.1/allure-commandline-2.17.1.zip"
+  },
+    {
+    "id": "2.17.0",
+    "name": "2.17.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.17.0/allure-commandline-2.17.0.zip"
+  },
+    {
+    "id": "2.16.1",
+    "name": "2.16.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.16.1/allure-commandline-2.16.1.zip"
+  },
+    {
+    "id": "2.16.0",
+    "name": "2.16.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.16.0/allure-commandline-2.16.0.zip"
+  },
+    {
+    "id": "2.15.0",
+    "name": "2.15.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.15.0/allure-commandline-2.15.0.zip"
+  },
+    {
+    "id": "2.14.0",
+    "name": "2.14.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.14.0/allure-commandline-2.14.0.zip"
+  },
+    {
+    "id": "2.13.10",
+    "name": "2.13.10",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.10/allure-commandline-2.13.10.zip"
+  },
+    {
+    "id": "2.13.9",
+    "name": "2.13.9",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.9/allure-commandline-2.13.9.zip"
+  },
+    {
+    "id": "2.13.8",
+    "name": "2.13.8",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.8/allure-commandline-2.13.8.zip"
+  },
+    {
+    "id": "2.13.7",
+    "name": "2.13.7",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.7/allure-commandline-2.13.7.zip"
+  },
+    {
+    "id": "2.13.6",
+    "name": "2.13.6",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.6/allure-commandline-2.13.6.zip"
+  },
+    {
+    "id": "2.13.5",
+    "name": "2.13.5",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.5/allure-commandline-2.13.5.zip"
+  },
+    {
+    "id": "2.13.4",
+    "name": "2.13.4",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.4/allure-commandline-2.13.4.zip"
+  },
+    {
+    "id": "2.13.3",
+    "name": "2.13.3",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.3/allure-commandline-2.13.3.zip"
+  },
+    {
+    "id": "2.13.2",
+    "name": "2.13.2",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.2/allure-commandline-2.13.2.zip"
+  },
+    {
+    "id": "2.13.1",
+    "name": "2.13.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.1/allure-commandline-2.13.1.zip"
+  },
+    {
+    "id": "2.13.0",
+    "name": "2.13.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.13.0/allure-commandline-2.13.0.zip"
+  },
+    {
+    "id": "2.12.1",
+    "name": "2.12.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.12.1/allure-commandline-2.12.1.zip"
+  },
+    {
+    "id": "2.12.0",
+    "name": "2.12.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.12.0/allure-commandline-2.12.0.zip"
+  },
+    {
+    "id": "2.11.0",
+    "name": "2.11.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.11.0/allure-commandline-2.11.0.zip"
+  },
+    {
+    "id": "2.10.0",
+    "name": "2.10.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.10.0/allure-commandline-2.10.0.zip"
+  },
+    {
+    "id": "2.9.0",
+    "name": "2.9.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.9.0/allure-commandline-2.9.0.zip"
+  },
+    {
+    "id": "2.8.1",
+    "name": "2.8.1",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.8.1/allure-commandline-2.8.1.zip"
+  },
+    {
+    "id": "2.8.0",
+    "name": "2.8.0",
+    "url": "https://repo1.maven.org/maven2/io/qameta/allure/allure-commandline/2.8.0/allure-commandline-2.8.0.zip"
+  },
+    {
+    "id": "1.5.4",
+    "name": "1.5.4",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.5.4/allure-commandline-1.5.4-standalone.zip"
+  },
+    {
+    "id": "1.5.3",
+    "name": "1.5.3",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.5.3/allure-commandline-1.5.3-standalone.zip"
+  },
+    {
+    "id": "1.5.2",
+    "name": "1.5.2",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.5.2/allure-commandline-1.5.2-standalone.zip"
+  },
+    {
+    "id": "1.5.1",
+    "name": "1.5.1",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.5.1/allure-commandline-1.5.1-standalone.zip"
+  },
+    {
+    "id": "1.5.0",
+    "name": "1.5.0",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.5.0/allure-commandline-1.5.0-standalone.zip"
+  },
+    {
+    "id": "1.4.23.HOTFIX1",
+    "name": "1.4.23.HOTFIX1",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.23.HOTFIX1/allure-commandline-1.4.23.HOTFIX1-standalone.zip"
+  },
+    {
+    "id": "1.4.23",
+    "name": "1.4.23",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.23/allure-commandline-1.4.23-standalone.zip"
+  },
+    {
+    "id": "1.4.22",
+    "name": "1.4.22",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.22/allure-commandline-1.4.22-standalone.zip"
+  },
+    {
+    "id": "1.4.21",
+    "name": "1.4.21",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.21/allure-commandline-1.4.21-standalone.zip"
+  },
+    {
+    "id": "1.4.20",
+    "name": "1.4.20",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.20/allure-commandline-1.4.20-standalone.zip"
+  },
+    {
+    "id": "1.4.19",
+    "name": "1.4.19",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.19/allure-commandline-1.4.19-standalone.zip"
+  },
+    {
+    "id": "1.4.18",
+    "name": "1.4.18",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.18/allure-commandline-1.4.18-standalone.zip"
+  },
+    {
+    "id": "1.4.17",
+    "name": "1.4.17",
+    "url": "https://oss.sonatype.org/content/repositories/releases/ru/yandex/qatools/allure/allure-commandline/1.4.17/allure-commandline-1.4.17.zip"
+  }
+]}

--- a/maven.groovy
+++ b/maven.groovy
@@ -7,6 +7,11 @@ import java.util.regex.Pattern
 import net.sf.json.JSONObject
 import hudson.util.VersionNumber
 
+// HACK HACK HACK HACK - https://github.com/jenkins-infra/crawler/issues/175 (phase 1)
+lib.DataWriter.write("hudson.tasks.Maven.MavenInstaller", JSONObject.fromObject(new File("maven.hack.json").text));
+System.exit(0)
+// End of HACK HACK HACK HACK
+
 def getHtmlPage(url) {
     def wc = new WebClient()
     wc.setCssErrorHandler(new org.htmlunit.SilentCssErrorHandler());

--- a/maven.hack.json
+++ b/maven.hack.json
@@ -1,0 +1,337 @@
+{"list": [
+    {
+    "id": "3.9.15",
+    "name": "3.9.15",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip"
+  },
+    {
+    "id": "3.9.14",
+    "name": "3.9.14",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip"
+  },
+    {
+    "id": "3.9.13",
+    "name": "3.9.13",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.13/apache-maven-3.9.13-bin.zip"
+  },
+    {
+    "id": "3.9.12",
+    "name": "3.9.12",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip"
+  },
+    {
+    "id": "3.9.11",
+    "name": "3.9.11",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip"
+  },
+    {
+    "id": "3.9.10",
+    "name": "3.9.10",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip"
+  },
+    {
+    "id": "3.9.9",
+    "name": "3.9.9",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip"
+  },
+    {
+    "id": "3.9.8",
+    "name": "3.9.8",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip"
+  },
+    {
+    "id": "3.9.7",
+    "name": "3.9.7",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip"
+  },
+    {
+    "id": "3.9.6",
+    "name": "3.9.6",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip"
+  },
+    {
+    "id": "3.9.5",
+    "name": "3.9.5",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip"
+  },
+    {
+    "id": "3.9.4",
+    "name": "3.9.4",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip"
+  },
+    {
+    "id": "3.9.3",
+    "name": "3.9.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip"
+  },
+    {
+    "id": "3.9.2",
+    "name": "3.9.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.zip"
+  },
+    {
+    "id": "3.9.1",
+    "name": "3.9.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip"
+  },
+    {
+    "id": "3.9.0",
+    "name": "3.9.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.0/apache-maven-3.9.0-bin.zip"
+  },
+    {
+    "id": "3.8.9",
+    "name": "3.8.9",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.9/apache-maven-3.8.9-bin.zip"
+  },
+    {
+    "id": "3.8.8",
+    "name": "3.8.8",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip"
+  },
+    {
+    "id": "3.8.7",
+    "name": "3.8.7",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip"
+  },
+    {
+    "id": "3.8.6",
+    "name": "3.8.6",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip"
+  },
+    {
+    "id": "3.8.5",
+    "name": "3.8.5",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip"
+  },
+    {
+    "id": "3.8.4",
+    "name": "3.8.4",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip"
+  },
+    {
+    "id": "3.8.3",
+    "name": "3.8.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip"
+  },
+    {
+    "id": "3.8.2",
+    "name": "3.8.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.2/apache-maven-3.8.2-bin.zip"
+  },
+    {
+    "id": "3.8.1",
+    "name": "3.8.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip"
+  },
+    {
+    "id": "3.6.3",
+    "name": "3.6.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip"
+  },
+    {
+    "id": "3.6.2",
+    "name": "3.6.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip"
+  },
+    {
+    "id": "3.6.1",
+    "name": "3.6.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip"
+  },
+    {
+    "id": "3.6.0",
+    "name": "3.6.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip"
+  },
+    {
+    "id": "3.5.4",
+    "name": "3.5.4",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip"
+  },
+    {
+    "id": "3.5.3",
+    "name": "3.5.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip"
+  },
+    {
+    "id": "3.5.2",
+    "name": "3.5.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip"
+  },
+    {
+    "id": "3.5.0",
+    "name": "3.5.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip"
+  },
+    {
+    "id": "3.3.9",
+    "name": "3.3.9",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
+  },
+    {
+    "id": "3.3.3",
+    "name": "3.3.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
+  },
+    {
+    "id": "3.3.1",
+    "name": "3.3.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+  },
+    {
+    "id": "3.2.5",
+    "name": "3.2.5",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
+  },
+    {
+    "id": "3.2.3",
+    "name": "3.2.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
+  },
+    {
+    "id": "3.2.2",
+    "name": "3.2.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.2/apache-maven-3.2.2-bin.zip"
+  },
+    {
+    "id": "3.2.1",
+    "name": "3.2.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip"
+  },
+    {
+    "id": "3.1.1",
+    "name": "3.1.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.1.1/apache-maven-3.1.1-bin.zip"
+  },
+    {
+    "id": "3.1.0",
+    "name": "3.1.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.1.0/apache-maven-3.1.0-bin.zip"
+  },
+    {
+    "id": "3.0.5",
+    "name": "3.0.5",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.5/apache-maven-3.0.5-bin.zip"
+  },
+    {
+    "id": "3.0.4",
+    "name": "3.0.4",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.4/apache-maven-3.0.4-bin.zip"
+  },
+    {
+    "id": "3.0.3",
+    "name": "3.0.3",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.3/apache-maven-3.0.3-bin.zip"
+  },
+    {
+    "id": "3.0.2",
+    "name": "3.0.2",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.2/apache-maven-3.0.2-bin.zip"
+  },
+    {
+    "id": "3.0.1",
+    "name": "3.0.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.1/apache-maven-3.0.1-bin.zip"
+  },
+    {
+    "id": "3.0",
+    "name": "3.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0/apache-maven-3.0-bin.zip"
+  },
+    {
+    "id": "2.2.1",
+    "name": "2.2.1",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.2.1/apache-maven-2.2.1-bin.zip"
+  },
+    {
+    "id": "2.2.0",
+    "name": "2.2.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.2.0/apache-maven-2.2.0-bin.zip"
+  },
+    {
+    "id": "2.1.0",
+    "name": "2.1.0",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.1.0/apache-maven-2.1.0-bin.zip"
+  },
+    {
+    "id": "2.0.11",
+    "name": "2.0.11",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.11/apache-maven-2.0.11-bin.zip"
+  },
+    {
+    "id": "2.0.10",
+    "name": "2.0.10",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.10/apache-maven-2.0.10-bin.zip"
+  },
+    {
+    "id": "2.0.9",
+    "name": "2.0.9",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/2.0.9/apache-maven-2.0.9-bin.zip"
+  },
+    {
+    "id": "2.0.8",
+    "name": "2.0.8",
+    "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.8-bin.zip"
+  },
+    {
+    "id": "2.0.7",
+    "name": "2.0.7",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.7-bin.zip"
+  },
+    {
+    "id": "2.0.6",
+    "name": "2.0.6",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.6-bin.zip"
+  },
+    {
+    "id": "2.0.5",
+    "name": "2.0.5",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.5-bin.zip"
+  },
+    {
+    "id": "2.0.4",
+    "name": "2.0.4",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.4-bin.zip"
+  },
+    {
+    "id": "2.0.3",
+    "name": "2.0.3",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.3-bin.zip"
+  },
+    {
+    "id": "2.0.2",
+    "name": "2.0.2",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.2-bin.zip"
+  },
+    {
+    "id": "2.0.1",
+    "name": "2.0.1",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.1-bin.zip"
+  },
+    {
+    "id": "2.0",
+    "name": "2.0",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0-bin.zip"
+  },
+    {
+    "id": "1.1",
+    "name": "1.1",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-1.1.zip"
+  },
+    {
+    "id": "1.0.2",
+    "name": "1.0.2",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.2.zip"
+  },
+    {
+    "id": "1.0.1",
+    "name": "1.0.1",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.1.zip"
+  },
+    {
+    "id": "1.0",
+    "name": "1.0",
+    "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.zip"
+  }
+]}

--- a/sbt.groovy
+++ b/sbt.groovy
@@ -8,6 +8,11 @@ import java.net.URL
 import java.util.regex.Pattern
 import net.sf.json.*
 
+// HACK HACK HACK HACK - https://github.com/jenkins-infra/crawler/issues/175 (phase 1)
+lib.DataWriter.write("org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller", JSONObject.fromObject(new File("sbt.hack.json").text));
+System.exit(0)
+// End of HACK HACK HACK HACK
+
 def listFromMavenRepo() {
     def versions = []
     def url = "https://repo1.maven.org/maven2/org/scala-sbt/sbt/";

--- a/sbt.hack.json
+++ b/sbt.hack.json
@@ -1,0 +1,532 @@
+{"list": [
+    {
+    "id": "1.12.11",
+    "name": "1.12.11",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.11/sbt-1.12.11.zip"
+  },
+    {
+    "id": "1.12.10",
+    "name": "1.12.10",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.10/sbt-1.12.10.zip"
+  },
+    {
+    "id": "1.12.9",
+    "name": "1.12.9",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.9/sbt-1.12.9.zip"
+  },
+    {
+    "id": "1.12.8",
+    "name": "1.12.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.8/sbt-1.12.8.zip"
+  },
+    {
+    "id": "1.12.7",
+    "name": "1.12.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.7/sbt-1.12.7.zip"
+  },
+    {
+    "id": "1.12.6",
+    "name": "1.12.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.6/sbt-1.12.6.zip"
+  },
+    {
+    "id": "1.12.5",
+    "name": "1.12.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.5/sbt-1.12.5.zip"
+  },
+    {
+    "id": "1.12.4",
+    "name": "1.12.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.4/sbt-1.12.4.zip"
+  },
+    {
+    "id": "1.12.3",
+    "name": "1.12.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.3/sbt-1.12.3.zip"
+  },
+    {
+    "id": "1.12.2",
+    "name": "1.12.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.2/sbt-1.12.2.zip"
+  },
+    {
+    "id": "1.12.1",
+    "name": "1.12.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.1/sbt-1.12.1.zip"
+  },
+    {
+    "id": "1.12.0",
+    "name": "1.12.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.12.0/sbt-1.12.0.zip"
+  },
+    {
+    "id": "1.11.7",
+    "name": "1.11.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.7/sbt-1.11.7.zip"
+  },
+    {
+    "id": "1.11.6",
+    "name": "1.11.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.6/sbt-1.11.6.zip"
+  },
+    {
+    "id": "1.11.5",
+    "name": "1.11.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.5/sbt-1.11.5.zip"
+  },
+    {
+    "id": "1.11.4",
+    "name": "1.11.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.4/sbt-1.11.4.zip"
+  },
+    {
+    "id": "1.11.3",
+    "name": "1.11.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.3/sbt-1.11.3.zip"
+  },
+    {
+    "id": "1.11.2",
+    "name": "1.11.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.2/sbt-1.11.2.zip"
+  },
+    {
+    "id": "1.11.1",
+    "name": "1.11.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.1/sbt-1.11.1.zip"
+  },
+    {
+    "id": "1.11.0",
+    "name": "1.11.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.11.0/sbt-1.11.0.zip"
+  },
+    {
+    "id": "1.10.11",
+    "name": "1.10.11",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.11/sbt-1.10.11.zip"
+  },
+    {
+    "id": "1.10.10",
+    "name": "1.10.10",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.10/sbt-1.10.10.zip"
+  },
+    {
+    "id": "1.10.9",
+    "name": "1.10.9",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.9/sbt-1.10.9.zip"
+  },
+    {
+    "id": "1.10.7",
+    "name": "1.10.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.7/sbt-1.10.7.zip"
+  },
+    {
+    "id": "1.10.6",
+    "name": "1.10.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.6/sbt-1.10.6.zip"
+  },
+    {
+    "id": "1.10.5",
+    "name": "1.10.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.5/sbt-1.10.5.zip"
+  },
+    {
+    "id": "1.10.4",
+    "name": "1.10.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.4/sbt-1.10.4.zip"
+  },
+    {
+    "id": "1.10.3",
+    "name": "1.10.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.3/sbt-1.10.3.zip"
+  },
+    {
+    "id": "1.10.2",
+    "name": "1.10.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.2/sbt-1.10.2.zip"
+  },
+    {
+    "id": "1.10.1",
+    "name": "1.10.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.1/sbt-1.10.1.zip"
+  },
+    {
+    "id": "1.10.0",
+    "name": "1.10.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.10.0/sbt-1.10.0.zip"
+  },
+    {
+    "id": "1.9.9",
+    "name": "1.9.9",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.9/sbt-1.9.9.zip"
+  },
+    {
+    "id": "1.9.8",
+    "name": "1.9.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.8/sbt-1.9.8.zip"
+  },
+    {
+    "id": "1.9.7",
+    "name": "1.9.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.7/sbt-1.9.7.zip"
+  },
+    {
+    "id": "1.9.6",
+    "name": "1.9.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.6/sbt-1.9.6.zip"
+  },
+    {
+    "id": "1.9.5",
+    "name": "1.9.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.5/sbt-1.9.5.zip"
+  },
+    {
+    "id": "1.9.4",
+    "name": "1.9.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.4/sbt-1.9.4.zip"
+  },
+    {
+    "id": "1.9.3",
+    "name": "1.9.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.3/sbt-1.9.3.zip"
+  },
+    {
+    "id": "1.9.2",
+    "name": "1.9.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.2/sbt-1.9.2.zip"
+  },
+    {
+    "id": "1.9.1",
+    "name": "1.9.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.1/sbt-1.9.1.zip"
+  },
+    {
+    "id": "1.9.0",
+    "name": "1.9.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.9.0/sbt-1.9.0.zip"
+  },
+    {
+    "id": "1.8.3",
+    "name": "1.8.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.8.3/sbt-1.8.3.zip"
+  },
+    {
+    "id": "1.8.2",
+    "name": "1.8.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.8.2/sbt-1.8.2.zip"
+  },
+    {
+    "id": "1.8.1",
+    "name": "1.8.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.8.1/sbt-1.8.1.zip"
+  },
+    {
+    "id": "1.8.0",
+    "name": "1.8.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.8.0/sbt-1.8.0.zip"
+  },
+    {
+    "id": "1.7.3",
+    "name": "1.7.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.7.3/sbt-1.7.3.zip"
+  },
+    {
+    "id": "1.7.2",
+    "name": "1.7.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.7.2/sbt-1.7.2.zip"
+  },
+    {
+    "id": "1.7.1",
+    "name": "1.7.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.7.1/sbt-1.7.1.zip"
+  },
+    {
+    "id": "1.7.0",
+    "name": "1.7.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.7.0/sbt-1.7.0.zip"
+  },
+    {
+    "id": "1.6.2",
+    "name": "1.6.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.6.2/sbt-1.6.2.zip"
+  },
+    {
+    "id": "1.6.1",
+    "name": "1.6.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.6.1/sbt-1.6.1.zip"
+  },
+    {
+    "id": "1.6.0",
+    "name": "1.6.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.6.0/sbt-1.6.0.zip"
+  },
+    {
+    "id": "1.5.8",
+    "name": "1.5.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.8/sbt-1.5.8.zip"
+  },
+    {
+    "id": "1.5.7",
+    "name": "1.5.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.7/sbt-1.5.7.zip"
+  },
+    {
+    "id": "1.5.6",
+    "name": "1.5.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.6/sbt-1.5.6.zip"
+  },
+    {
+    "id": "1.5.5",
+    "name": "1.5.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.5/sbt-1.5.5.zip"
+  },
+    {
+    "id": "1.5.4",
+    "name": "1.5.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.4/sbt-1.5.4.zip"
+  },
+    {
+    "id": "1.5.3",
+    "name": "1.5.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.3/sbt-1.5.3.zip"
+  },
+    {
+    "id": "1.5.2",
+    "name": "1.5.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.2/sbt-1.5.2.zip"
+  },
+    {
+    "id": "1.5.1",
+    "name": "1.5.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.1/sbt-1.5.1.zip"
+  },
+    {
+    "id": "1.5.0",
+    "name": "1.5.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.5.0/sbt-1.5.0.zip"
+  },
+    {
+    "id": "1.4.9",
+    "name": "1.4.9",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.9/sbt-1.4.9.zip"
+  },
+    {
+    "id": "1.4.8",
+    "name": "1.4.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.8/sbt-1.4.8.zip"
+  },
+    {
+    "id": "1.4.7",
+    "name": "1.4.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.7/sbt-1.4.7.zip"
+  },
+    {
+    "id": "1.4.6",
+    "name": "1.4.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.6/sbt-1.4.6.zip"
+  },
+    {
+    "id": "1.4.5",
+    "name": "1.4.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.5/sbt-1.4.5.zip"
+  },
+    {
+    "id": "1.4.4",
+    "name": "1.4.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.4/sbt-1.4.4.zip"
+  },
+    {
+    "id": "1.4.3",
+    "name": "1.4.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.3/sbt-1.4.3.zip"
+  },
+    {
+    "id": "1.4.2",
+    "name": "1.4.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.2/sbt-1.4.2.zip"
+  },
+    {
+    "id": "1.4.1",
+    "name": "1.4.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.zip"
+  },
+    {
+    "id": "1.4.0",
+    "name": "1.4.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.4.0/sbt-1.4.0.zip"
+  },
+    {
+    "id": "1.3.13",
+    "name": "1.3.13",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.13/sbt-1.3.13.zip"
+  },
+    {
+    "id": "1.3.12",
+    "name": "1.3.12",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.12/sbt-1.3.12.zip"
+  },
+    {
+    "id": "1.3.11",
+    "name": "1.3.11",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.11/sbt-1.3.11.zip"
+  },
+    {
+    "id": "1.3.10",
+    "name": "1.3.10",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.10/sbt-1.3.10.zip"
+  },
+    {
+    "id": "1.3.9",
+    "name": "1.3.9",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.9/sbt-1.3.9.zip"
+  },
+    {
+    "id": "1.3.8",
+    "name": "1.3.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.8/sbt-1.3.8.zip"
+  },
+    {
+    "id": "1.3.7",
+    "name": "1.3.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.7/sbt-1.3.7.zip"
+  },
+    {
+    "id": "1.3.6",
+    "name": "1.3.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.6/sbt-1.3.6.zip"
+  },
+    {
+    "id": "1.3.5",
+    "name": "1.3.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.5/sbt-1.3.5.zip"
+  },
+    {
+    "id": "1.3.4",
+    "name": "1.3.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.4/sbt-1.3.4.zip"
+  },
+    {
+    "id": "1.3.3",
+    "name": "1.3.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.3/sbt-1.3.3.zip"
+  },
+    {
+    "id": "1.3.2",
+    "name": "1.3.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.2/sbt-1.3.2.zip"
+  },
+    {
+    "id": "1.3.1",
+    "name": "1.3.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.1/sbt-1.3.1.zip"
+  },
+    {
+    "id": "1.3.0",
+    "name": "1.3.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.3.0/sbt-1.3.0.zip"
+  },
+    {
+    "id": "1.2.8",
+    "name": "1.2.8",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.8/sbt-1.2.8.zip"
+  },
+    {
+    "id": "1.2.7",
+    "name": "1.2.7",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.7/sbt-1.2.7.zip"
+  },
+    {
+    "id": "1.2.6",
+    "name": "1.2.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.6/sbt-1.2.6.zip"
+  },
+    {
+    "id": "1.2.5",
+    "name": "1.2.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.5/sbt-1.2.5.zip"
+  },
+    {
+    "id": "1.2.4",
+    "name": "1.2.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.4/sbt-1.2.4.zip"
+  },
+    {
+    "id": "1.2.3",
+    "name": "1.2.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.3/sbt-1.2.3.zip"
+  },
+    {
+    "id": "1.2.1",
+    "name": "1.2.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.1/sbt-1.2.1.zip"
+  },
+    {
+    "id": "1.2.0",
+    "name": "1.2.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.2.0/sbt-1.2.0.zip"
+  },
+    {
+    "id": "1.1.6",
+    "name": "1.1.6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.6/sbt-1.1.6.zip"
+  },
+    {
+    "id": "1.1.5",
+    "name": "1.1.5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.5/sbt-1.1.5.zip"
+  },
+    {
+    "id": "1.1.4",
+    "name": "1.1.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.4/sbt-1.1.4.zip"
+  },
+    {
+    "id": "1.1.3",
+    "name": "1.1.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.3/sbt-1.1.3.zip"
+  },
+    {
+    "id": "1.1.2",
+    "name": "1.1.2",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.2/sbt-1.1.2.zip"
+  },
+    {
+    "id": "1.1.1",
+    "name": "1.1.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.1/sbt-1.1.1.zip"
+  },
+    {
+    "id": "1.1.0",
+    "name": "1.1.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.1.0/sbt-1.1.0.zip"
+  },
+    {
+    "id": "1.0.4",
+    "name": "1.0.4",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.4/sbt-1.0.4.zip"
+  },
+    {
+    "id": "1.0.3",
+    "name": "1.0.3",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.3/sbt-1.0.3.zip"
+  },
+    {
+    "id": "1.0.1",
+    "name": "1.0.1",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.1/sbt-1.0.1.zip"
+  },
+    {
+    "id": "1.0.0",
+    "name": "1.0.0",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.0/sbt-1.0.0.zip"
+  },
+    {
+    "id": "1.0.0-M6",
+    "name": "1.0.0-M6",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.0-M6/sbt-1.0.0-M6.zip"
+  },
+    {
+    "id": "1.0.0-M5",
+    "name": "1.0.0-M5",
+    "url": "https://github.com/sbt/sbt/releases/download/v1.0.0-M5/sbt-1.0.0-M5.zip"
+  }
+]}


### PR DESCRIPTION
## Do not scrape Maven Central for tool releases

Maven Central has implemented rate limiting that blocks our simplified scraping for tool releases.  Temporarily use a local copy of the scraped data instead of scraping Maven Central.

This is phase 1 as described in https://github.com/jenkins-infra/crawler/issues/175#issuecomment-4413608199

- Populate allure releases from a local copy, don't scrape Maven Central
- Populate maven releases from a local copy, don't scrape Maven Central
- Populate sbt releases from a local copy, don't scrape Maven Central
