### PR TITLE
Adds Maven 3.9.16 to hardcoded list of Maven versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,7 @@ node('maven-17') {
         "PATH+GROOVY=${tool 'groovy'}/bin",
     ]) {
         stage('Build') {
-            sh 'mvn -v'
-            sh 'mvn -e clean install'
+            sh 'mvn -V -B -e clean install'
         }
 
         stage('Generate') {

--- a/maven.hack.json
+++ b/maven.hack.json
@@ -1,5 +1,10 @@
 {"list": [
     {
+    "id": "3.9.16",
+    "name": "3.9.16",
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip"
+  },
+    {
     "id": "3.9.15",
     "name": "3.9.15",
     "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip"


### PR DESCRIPTION
This file is an on going hack due to Maven central rate limits

https://github.com/apache/maven/releases/tag/maven-3.9.16

Relates to #176 and #175. 
